### PR TITLE
Fix logout issue

### DIFF
--- a/src/IdentityManager2/Api/Controllers/PageController.cs
+++ b/src/IdentityManager2/Api/Controllers/PageController.cs
@@ -70,13 +70,13 @@ namespace IdentityManager2.Api.Controllers
         [HttpGet]
         [AllowAnonymous]
         [Route("api/logout", Name = IdentityManagerConstants.RouteNames.Logout)]
-        public async Task<IActionResult> Logout()
+        public async Task Logout()
         {
             await HttpContext.SignOutAsync(IdentityManagerConstants.LocalApiScheme);
 
             await config.SecurityConfiguration.SignOut(HttpContext);
 
-            return RedirectToRoute(IdentityManagerConstants.RouteNames.Home, null);
+            await HttpContext.SignOutAsync("oidc");
         }
     }
 }


### PR DESCRIPTION
Fix issue were logout was not passing the "oidc" scheme to the Signout method. This prevented Identityserver4 from completing the logout cycle. 