### PR TITLE
Fix displaying user creation error messages

### DIFF
--- a/src/IdentityManager2/Api/Controllers/UsersController.cs
+++ b/src/IdentityManager2/Api/Controllers/UsersController.cs
@@ -84,7 +84,9 @@ namespace IdentityManager2.Api.Controllers
                     return Created(url, resource);
                 }
 
-                ModelState.AddModelError("", result.ToString());
+                ModelState.AddModelError("errors", result.Errors.Aggregate((workingSentence, next) => workingSentence + " " + next));
+                if(result.Errors.Count > 0)
+                    return BadRequest(ModelState);
             }
 
             return BadRequest(400);


### PR DESCRIPTION
When creating user with not complex enough passwords error is not show on screen.
This fixes that https://github.com/IdentityManager/IdentityManager2/issues/21